### PR TITLE
feat: make the about section responsive

### DIFF
--- a/src/components/sections/about/about-section.tsx
+++ b/src/components/sections/about/about-section.tsx
@@ -4,7 +4,7 @@ import { Content } from "./content";
 export function AboutSection() {
   return (
     <div
-      className="min-h-screen w-full flex justify-evenly items-center"
+      className="w-full mt-10 pt-5 flex flex-col md:mt-0 md:flex-row md:justify-evenly md:items-center"
       id="about"
     >
       <Heading />

--- a/src/components/sections/about/content.tsx
+++ b/src/components/sections/about/content.tsx
@@ -9,13 +9,14 @@ export function Content() {
   const isInView = useInView(ref, { once: true });
 
   return (
-    <div className="w-1/2 flex flex-col" ref={ref}>
+    <div className="lg:w-1/2" ref={ref}>
       <div
         style={{
           transform: isInView ? "none" : "translateX(200px)",
           opacity: isInView ? 1 : 0,
           transition: "all 0.9s cubic-bezier(0.17, 0.55, 0.55, 1) 0.5s",
         }}
+        className="flex flex-col items-center"
       >
         <p className="text-lg pb-10">
           I am an aspiring software engineer, specializing in full-stack
@@ -25,14 +26,14 @@ export function Content() {
           adept at working with cross-functional teams and determined to provide
           a high-quality solution at all times.
         </p>
-        <div className="self-center">
+        <div>
           <a
             className="flex items-center gap-x-1 font-bold transition-all hover:text-primary"
             href="#projects"
           >
             Scroll below or click here to check out the projects that I have
             made
-            <ChevronDownIcon />
+            <ChevronDownIcon height={24} width={24} />
           </a>
         </div>
       </div>

--- a/src/components/sections/about/heading.tsx
+++ b/src/components/sections/about/heading.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 import * as React from "react";
 import { useInView } from "framer-motion";
@@ -17,7 +17,7 @@ export function Heading() {
         }}
       >
         <h1 className="font-bold text-5xl md:text-6xl lg:text-8xl">About</h1>
-        <h3 className="text-xl">Find out all about who I am and what I do</h3>
+        <p className="text-lg">Find out all about who I am and what I do</p>
       </div>
     </div>
   );

--- a/src/components/sections/about/heading.tsx
+++ b/src/components/sections/about/heading.tsx
@@ -17,7 +17,7 @@ export function Heading() {
         }}
       >
         <h1 className="font-bold text-5xl md:text-6xl lg:text-8xl">About</h1>
-        <p className="text-lg">Find out all about who I am and what I do</p>
+        <h3 className="text-lg">Find out all about who I am and what I do</h3>
       </div>
     </div>
   );

--- a/src/components/sections/contact-section.tsx
+++ b/src/components/sections/contact-section.tsx
@@ -11,7 +11,7 @@ import {
 
 export function ContactSection() {
   return (
-    <div id="contact" className="min-h-screen flex items-center justify-center">
+    <div id="contact" className="mt-10 flex items-center justify-center">
       <Card>
         <CardHeader>
           <CardTitle>Contact me</CardTitle>

--- a/src/components/sections/home/home-section.tsx
+++ b/src/components/sections/home/home-section.tsx
@@ -20,7 +20,7 @@ export function HomeSection() {
   ];
 
   return (
-    <main className="text-tarawera-50 font-bold flex flex-col items-center md:flex-row md:justify-center md:items-center">
+    <main className="text-tarawera-50 font-bold flex flex-col items-center justify-center md:flex-row md:justify-center md:items-center">
       <TitleImage />
       <div className="flex flex-col">
         <Heading />

--- a/src/components/sections/projects/projects-section.tsx
+++ b/src/components/sections/projects/projects-section.tsx
@@ -28,7 +28,7 @@ export function ProjectsSection() {
   return (
     <div
       id="projects"
-      className="min-h-screen flex flex-col items-center justify-center md:flex-row md:items-center md:justify-evenly"
+      className="w-full mt-10 pt-5 flex flex-col items-center justify-center md:flex-row md:items-center md:justify-evenly"
     >
       <Heading />
       <Content>


### PR DESCRIPTION
This PR makes the about section responsive. I also made some additional changes to the overall layout of the portfolio. Instead of giving each section a default height of the screen I am just using the automatically set height of each section.